### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/IvanNardi/pl7m/security/code-scanning/1](https://github.com/IvanNardi/pl7m/security/code-scanning/1)

In general, the fix is to explicitly specify `permissions` for the workflow or for individual jobs so that the `GITHUB_TOKEN` has only the minimal required access. For a simple build-and-test job that only checks out the repository and runs local commands, read-only access to repository contents is sufficient.

The best way to fix this without changing existing functionality is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`). That way, all jobs inherit these minimal permissions unless they explicitly override them. For this workflow, we can safely set `contents: read`, since the only GitHub operation is `actions/checkout`, which requires read access to the repository contents. Concretely, in `.github/workflows/build.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: Build` line and the `on:` block (i.e., after line 1, before line 2). No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
