### PR TITLE
Potential fix for code scanning alert no. 2: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/pl7m.c
+++ b/pl7m.c
@@ -755,7 +755,7 @@ static int is_gtp_u(unsigned char *gtp_buffer, int gtp_buffer_len,
 {
 	struct gtp_header *gtp_h;
 	struct udphdr *udp_h;
-	uint16_t new_layer_len = 0;
+	int new_layer_len = 0;
 	unsigned char sub_proto;
 
 	if (p->l4_proto != IPPROTO_UDP ||


### PR DESCRIPTION
Potential fix for [https://github.com/IvanNardi/pl7m/security/code-scanning/2](https://github.com/IvanNardi/pl7m/security/code-scanning/2)

Use a loop/index variable type at least as wide as `gtp_buffer_len` for comparisons and arithmetic, then cast back only at return after validation.

Best minimal fix in `pl7m.c` (within `is_gtp_u`):
- Change `new_layer_len` from `uint16_t` to `int`.
- Keep existing logic intact.
- Add a final guard before return to ensure the value is representable by the `int` return type semantics already used (here already `int`, so just return directly).
- This removes narrow-type overflow risk in the loop condition and arithmetic without changing behavior for valid inputs.

No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
